### PR TITLE
Support of http and https connection when using ignore_ssl_validation

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -60,6 +60,7 @@ module Manticore
     include_package "org.apache.http.client.entity"
     include_package "org.apache.http.client.config"
     include_package "org.apache.http.config"
+    include_package "org.apache.http.conn.socket"
     include_package "org.apache.http.impl"
     include_package "org.apache.http.impl.client"
     include_package "org.apache.http.impl.conn"
@@ -292,7 +293,7 @@ module Manticore
       if options.fetch(:ignore_ssl_validation, false)
         context  = SSLContexts.custom.load_trust_material(nil, TrustSelfSignedStrategy.new).build
         sslsf    = SSLConnectionSocketFactory.new(context, SSLConnectionSocketFactory::ALLOW_ALL_HOSTNAME_VERIFIER)
-        registry = RegistryBuilder.create.register("https", sslsf).build
+        registry = RegistryBuilder.create.register("https", sslsf).register("http", PlainConnectionSocketFactory.new()).build
         PoolingHttpClientConnectionManager.new(registry)
       else
         PoolingHttpClientConnectionManager.new


### PR DESCRIPTION
closes #7
- add a registery "http" -> PlainConnectionSocketFactory to the connection pool
