### PR TITLE
Add a regression test for #7 and #8

### DIFF
--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -46,6 +46,10 @@ describe Manticore::Client do
     context "when on" do
       let(:client) { Manticore::Client.new ignore_ssl_validation: true }
 
+      it 'should not break on non-SSL URLs' do
+        client.get(local_server('/')).code.should == 200
+      end
+
       it "should not break on SSL validation errors" do
         expect { client.get("https://localhost:55444/").body }.to_not raise_exception
       end


### PR DESCRIPTION
This commit adds a simple regression test to ensure that HTTP pages
can be loaded when SSL verification is disabled.
