### PR TITLE
SSL Refactor

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -124,6 +124,13 @@ module Manticore
     #                                                     then connections will be kept alive for this long when Connection: keep-alive
     #                                                     is sent, but no Keep-Alive header is sent.
     def initialize(options = {})
+      # Support Deprecated Option
+      if options[:ignore_ssl_validation]
+        $stderr.puts 'The options[:ignore_ssl_validation] setting is deprecated in favor of options[:ssl][verify]!'
+        options[:ssl] ||= {}
+        options[:ssl]   = {:verify => !options.delete(:ignore_ssl_validation)}.merge(options[:ssl])
+      end
+
       builder  = client_builder
       builder.set_user_agent options.fetch(:user_agent, "Manticore #{VERSION}")
       @use_cookies = options.fetch(:cookies, false)
@@ -291,7 +298,7 @@ module Manticore
 
     def pool_builder(options)
       http_sf  = PlainConnectionSocketFactory.new
-      https_sf = ssl_sf_from_options(options)
+      https_sf = ssl_sf_from_options(options.fetch(:ssl, {}))
       registry = RegistryBuilder.create.register("http", http_sf).register("https", https_sf).build
       PoolingHttpClientConnectionManager.new(registry)
     end
@@ -460,8 +467,9 @@ module Manticore
     end
 
     # Configure the SSL Context
-    def ssl_sf_from_options(options)
-      if options.fetch(:ignore_ssl_validation, false)
+    def ssl_sf_from_options(ssl_options)
+      ### Trust Root Settings ###
+      if ssl_options.fetch(:verify, true) == false
         context = SSLContexts.custom.load_trust_material(nil, TrustSelfSignedStrategy.new).build
         SSLConnectionSocketFactory.new(context, SSLConnectionSocketFactory::ALLOW_ALL_HOSTNAME_VERIFIER)
       else

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -42,7 +42,7 @@ describe Manticore::Client do
     j["uri"]["port"].should == 55441
   end
 
-  describe "ignore_ssl_validation" do
+  describe "ignore_ssl_validation (deprecated option)" do
     context "when on" do
       let(:client) { Manticore::Client.new ignore_ssl_validation: true }
 
@@ -56,6 +56,34 @@ describe Manticore::Client do
 
       it "should break on SSL validation errors" do
         expect { client.get("https://localhost:55444/").call }.to raise_exception(Manticore::ClientProtocolException)
+      end
+    end
+  end
+
+  describe 'ssl settings' do
+    describe 'verify' do
+      context 'default' do
+        let(:client) { Manticore::Client.new }
+
+        it "should break on SSL validation errors" do
+          expect { client.get("https://localhost:55444/").call }.to raise_exception(Manticore::ClientProtocolException)
+        end
+      end
+
+      context 'when on' do
+        let(:client) { Manticore::Client.new :ssl => {:verify => true} }
+
+        it "should break on SSL validation errors" do
+          expect { client.get("https://localhost:55444/").call }.to raise_exception(Manticore::ClientProtocolException)
+        end
+      end
+
+      context 'when off' do
+        let(:client) { Manticore::Client.new :ssl => {:verify => false} }
+
+        it "should not break on SSL validation errors" do
+          expect { client.get("https://localhost:55444/").body }.to_not raise_exception
+        end
       end
     end
   end


### PR DESCRIPTION
This isolates SSL configuration and generally implements the low hanging fruit called out in #10. The more robust functionality, such as custom truststore/keystore settings, will be following in time, but will require some changes to the existing SSL test framework.
