### PR TITLE
Added a HTTP Status text method

### DIFF
--- a/lib/manticore/response.rb
+++ b/lib/manticore/response.rb
@@ -128,6 +128,14 @@ module Manticore
       @code
     end
 
+    # Return the response text for a request as a string (Not Found, Ok, Bad Request, etc). Will call the request if it has not been called yet.
+    #
+    # @return [String] The response code text
+    def message
+      call_once
+      @message
+    end
+
     # Returns the length of the response body. Returns -1 if content-length is not present in the response.
     #
     # @return [Integer]
@@ -206,6 +214,7 @@ module Manticore
     def handleResponse(response)
       @response        = response
       @code            = response.get_status_line.get_status_code
+      @message         = response.get_status_line.get_reason_phrase
       @headers         = Hash[* response.get_all_headers.flat_map {|h| [h.get_name.downcase, h.get_value]} ]
       @callback_result = @handlers[:success].call(self)
       nil

--- a/spec/manticore/response_spec.rb
+++ b/spec/manticore/response_spec.rb
@@ -12,6 +12,14 @@ describe Manticore::Response do
     subject.body.should match "Manticore"
   end
 
+  it "should read the status code" do
+    subject.code.should eq 200
+  end
+
+  it "should read the status text" do
+    subject.message.should match "OK"
+  end
+
   context "when the client is invoked with a block" do
     it "should allow reading the body from a block" do
       response = client.get(local_server) do |response|


### PR DESCRIPTION
I don't actually have a good suggestion on the name for this. Ruby uses `message` thought.
