### PR TITLE
Fix example for truststore to use correct option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ To set this up, you might create 2 pools, each configured for the task:
 
 ```ruby
 general_http_client    = Manticore::Client.new connect_timeout: 10, socket_timeout: 10, request_timeout: 10, follow_redirects: true, max_per_route: 2
+# With an OpenSSL CA store
 proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", ssl: {ca_file: "my_certs.pem"}
+# Or with a .jks truststore
+# proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", ssl: {truststore: "./truststore.jks", truststore_password: "s3cr3t"}
 ```
 
 This would create 2 separate request pools; the first would be configured with generous timeouts and redirect following, and would use the system

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ To set this up, you might create 2 pools, each configured for the task:
 
 ```ruby
 general_http_client    = Manticore::Client.new connect_timeout: 10, socket_timeout: 10, request_timeout: 10, follow_redirects: true, max_per_route: 2
-proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", truststore: "./truststore.jks", truststore_password: "s3cr3t"
+proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", ssl: {truststore: "./truststore.jks", truststore_password: "s3cr3t"}
+with_custom_ca = Manticore::Client.new ssl: {ca_file: "my_certs.pem"}
 ```
 
 This would create 2 separate request pools; the first would be configured with generous timeouts and redirect following, and would use the system

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ To set this up, you might create 2 pools, each configured for the task:
 
 ```ruby
 general_http_client    = Manticore::Client.new connect_timeout: 10, socket_timeout: 10, request_timeout: 10, follow_redirects: true, max_per_route: 2
-proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", ssl: {truststore: "./truststore.jks", truststore_password: "s3cr3t"}
-with_custom_ca = Manticore::Client.new ssl: {ca_file: "my_certs.pem"}
+proxied_backend_client = Manticore::Client.new proxy: "https://backend.internal:4242", ssl: {ca_file: "my_certs.pem"}
 ```
 
 This would create 2 separate request pools; the first would be configured with generous timeouts and redirect following, and would use the system


### PR DESCRIPTION
Also add `ca_file` example

This really confused me till I dug into the source.