### PR TITLE
Stop using Faraday open_timeout as socket_timeout

### DIFF
--- a/lib/faraday/adapter/manticore.rb
+++ b/lib/faraday/adapter/manticore.rb
@@ -56,8 +56,8 @@ module Faraday
         opts[:body] = body if body
 
         if req = env[:request]
-          opts[:request_timeout] = opts[:connect_timeout] = opts[:socket_timeout] = req[:timeout] if req.key?(:timeout)
-          opts[:connect_timeout] = opts[:socket_timeout] = req[:open_timeout] if req.key?(:open_timeout)
+          opts[:request_timeout] = opts[:socket_timeout] = opts[:connect_timeout] = req[:timeout] if req.key?(:timeout)
+          opts[:connect_timeout] = req[:open_timeout] if req.key?(:open_timeout)
           if prx = req[:proxy]
             opts[:proxy] = {
               :url      => prx[:uri].to_s,


### PR DESCRIPTION
We recently had some issues where our sockets were timing out far quicker than expected.

Manticore (HttpClient) supports 3 timeouts:

* **connectTimeout** - timeout during connection establishment (e.g. TCP handshake)
* **socketTimeout** - idle connection timeout
* **connectionRequestTimeout** - timeout retrieving a connection from the pooled connection manager

Faraday has 2 timeouts:

* **open_timeout** - intended to be the connection establishment timeout
* **timeout** - intended to be the idle connection timeout

The Faraday adapter in Manticore is assigning the Faraday `:timeout` to all 3 of its timeouts, if present. This is reasonable.

However, it would then assign the `:open_timeout` to both the `:socket_timeout` and  `:connect_timeout`. This is broken.

For example, a connection intended to have a 1 second connect timeout and a 15 second socket timeount would timeout after 1 second of idle time.