### PR TITLE
Ensure that Manticore will accept URI instances in addition to String…

### DIFF
--- a/lib/manticore/response.rb
+++ b/lib/manticore/response.rb
@@ -44,7 +44,7 @@ module Manticore
     # Used by Manticore::Client to invoke the request tied to this response.
     def call
       return background! if @background
-      raise "Already called" if @called
+      return self if @called
       @called = true
       begin
         @client.client.execute @request, self, @context

--- a/spec/manticore/response_spec.rb
+++ b/spec/manticore/response_spec.rb
@@ -85,6 +85,17 @@ describe Manticore::Response do
         expect { response.call }.to change { responses[:complete] }.to true
       end
     end
+  end
 
+  context "when the response has already been called" do
+    let(:response) { client.get(local_server).call }
+
+    it "does not raise an error" do
+      expect { response.call }.to_not raise_error
+    end
+
+    it "returns self" do
+      expect(response.call.object_id).to eq(response.object_id)
+    end
   end
 end


### PR DESCRIPTION
Fist of all I would like to say thanks for making such a great HTTP lib for JRuby. I use it a lot :+1: 


Instead of raising "Already called" Runtime Error, just return self since the response has already been called. I am not positive this is behaviour you want, but I decided to open a PR instead of an issue since it was a simple fix.

I ran across a use case today where this behaviour is valuable (although it is not a common use case). In an application I work on, we use the #call() method directly, rather than waiting until we need to body, or code, etc.  Today I was trying to implement webmock into our test suite, however webmock invokes #call() directly:

https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/manticore_adapter.rb#L53

Since webmock invokes #call() directly, when our code invokes #call(), a RuntimeError "Already called" is raised.

I realize that my specific issue is in the webmock adapter implementation, but it got me wondering why not just return the same response if #call() is invoked multiple times. Do you have a specific reason why we should limit the number of times you can call #call()?

One potential issue with this "fix" is that exceptions are only raised on the first #call() invocation.

