### PR TITLE
Travis: Include latest stable release of JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 rvm:
   - jruby-1.7
   - jruby-9.0.5.0
+  - jruby-9.1.8.0
 jdk:
   - oraclejdk8
   - oraclejdk7


### PR DESCRIPTION
This PR adds JRuby 9.1.8.0 to the build matrix in CI.