### PR TITLE
CHANGELOG: drop "pending" about 0.6.1 [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.6
 
-### v0.6.1 (pending)
+### v0.6.1
 
 * Manticore will accept a URI object (which it calls #to_s on) as an alternate to a String for the URL in client#get(url)
 


### PR DESCRIPTION
This PR edits the top of the changelog to not confuse the reader about whether 0.6.1 is released. It is no longer "pending".