### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 rvm:
   - jruby-1.7
   - jruby-9.0.5.0
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
 jdk:
   - oraclejdk8
   - oraclejdk7


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html