### PR TITLE
Travis: jruby-9.2.0.0 runs on Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
 rvm:
   - jruby-1.7
   - jruby-9.0.5.0
-  - jruby-9.2.0.0
 jdk:
   - oraclejdk8
   - openjdk7
@@ -16,6 +15,8 @@ before_install:
   - bundle install
 matrix:
   include:
+    - rvm: jruby-9.2.0.0
+      jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8
   allow_failures:


### PR DESCRIPTION
The build failed like:

```
Exception in thread "main" java.lang.UnsupportedClassVersionError: org/jruby/Main : Unsupported major.minor version 52.0
	at java.lang.ClassLoader.findBootstrapClass(Native Method)
	at java.lang.ClassLoader.findBootstrapClassOrNull(ClassLoader.java:1073)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:414)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:412)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:312)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:482)
```

https://stackoverflow.com/questions/10382929/how-to-fix-java-lang-unsupportedclassversionerror-unsupported-major-minor-versi

The proposed fix is to **only offer Java 8 to JRuby 9.2.0.0**.

Result: This change makes the build start, run, and then reporting having 1 failing test.