### PR TITLE
Travis: Use jruby-9.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - bundle install
 matrix:
   include:
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.5.0
       jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)