### PR TITLE
CI: Use jruby-9.2.7.0, loosen Bundler dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache:
   - bundler
   - directories:
@@ -15,7 +14,7 @@ before_install:
   - bundle install
 matrix:
   include:
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ jdk:
   - oraclejdk8
   - openjdk7
 before_install:
-  - gem install ruby-maven bundler
+  - gem install ruby-maven
+  - gem install bundler -v 1.17.3
   - bundle install
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - bundle install
 matrix:
   include:
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8

--- a/manticore.gemspec
+++ b/manticore.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "openssl_pkcs8_pure"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "jar-dependencies"
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.7.0**.

[JRuby 9.2.7.0 release blog post](https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html)

- Also: Allow Bundler 2 in the gemspec
- Use Bundler 1.17.3 in the CI builds, to suit all versions