### PR TITLE
CI: Use jruby-9.2.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - jruby-1.7
   - jruby-9.0.5.0
 jdk:
-  - oraclejdk8
+  - oraclejdk9
   - openjdk7
 before_install:
   - gem install ruby-maven
@@ -16,8 +16,8 @@ before_install:
 matrix:
   include:
     - rvm: jruby-9.2.13.0
-      jdk: oraclejdk8
+      jdk: oraclejdk9
     - rvm: jruby-head
-      jdk: oraclejdk8
+      jdk: oraclejdk9
   allow_failures:
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - bundle install
 matrix:
   include:
-    - rvm: jruby-9.2.11.0
+    - rvm: jruby-9.2.13.0
       jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - bundle install
 matrix:
   include:
-    - rvm: jruby-9.2.7.0
+    - rvm: jruby-9.2.11.0
       jdk: oraclejdk8
     - rvm: jruby-head
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,15 @@ cache:
   - bundler
   - directories:
     - $HOME/.m2
-rvm:
-  - jruby-1.7
-  - jruby-9.0.5.0
-jdk:
-  - oraclejdk9
-  - openjdk7
 before_install:
   - gem install ruby-maven
   - gem install bundler -v 1.17.3
-  - bundle install
 matrix:
   include:
+    - rvm: jruby-9.1.17.0
+      jdk: oraclejdk9
+    - rvm: jruby-9.1.17.0
+      jdk: openjdk7
     - rvm: jruby-9.2.13.0
       jdk: oraclejdk9
     - rvm: jruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.13.0**.

---

PS: I made a merge request in GitLab to the same effect. This is more of an informative PR.