### PR TITLE
Refactor: import Java class(es) from package directly

### DIFF
--- a/lib/manticore.rb
+++ b/lib/manticore.rb
@@ -5,7 +5,11 @@ require "cgi"
 require_relative "./manticore_jars.rb"
 require_relative "./org/manticore/manticore-ext"
 
-org.manticore.Manticore.new.load(JRuby.runtime, false)
+if defined? JRuby::Util.load_ext
+  JRuby::Util.load_ext 'org.manticore.Manticore'
+else
+  org.manticore.Manticore.new.load(JRuby.runtime, false)
+end
 
 require_relative "./manticore/version"
 

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -80,7 +80,6 @@ module Manticore
     include_package "org.apache.http.auth"
     include_package "java.util.concurrent"
     include_package "org.apache.http.client.protocol"
-    include_package "org.apache.http.conn.ssl"
     include_package "java.security.cert"
     include_package "java.security.spec"
     include_package "java.security"
@@ -90,6 +89,9 @@ module Manticore
     java_import "org.manticore.HttpGetWithEntity"
     java_import "org.manticore.HttpDeleteWithEntity"
     java_import "org.apache.http.auth.UsernamePasswordCredentials"
+    java_import "org.apache.http.conn.ssl.SSLConnectionSocketFactory"
+    java_import "org.apache.http.conn.ssl.SSLContextBuilder"
+    java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
 
     # This is a class rather than a proc because the proc holds a closure around
     # the instance of the Client that creates it.
@@ -618,7 +620,7 @@ module Manticore
         raise "Invalid value for :verify. Valid values are (:all, :browser, :default)"
       end
 
-      context = SSLContexts.custom
+      context = SSLContextBuilder.new
       setup_trust_store ssl_options, context, trust_strategy
       setup_key_store ssl_options, context
 

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -83,7 +83,6 @@ module Manticore
     include_package "java.security.cert"
     include_package "java.security.spec"
     include_package "java.security"
-    include_package "org.apache.http.client.utils"
     java_import "org.apache.http.HttpHost"
     java_import "javax.net.ssl.SSLContext"
     java_import "org.manticore.HttpGetWithEntity"
@@ -92,6 +91,7 @@ module Manticore
     java_import "org.apache.http.conn.ssl.SSLConnectionSocketFactory"
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
     java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
+    java_import "org.apache.http.client.utils.URIBuilder"
 
     # This is a class rather than a proc because the proc holds a closure around
     # the instance of the Client that creates it.

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -69,7 +69,6 @@ module Manticore
     include_package "org.apache.http.client.config"
     include_package "org.apache.http.config"
     include_package "org.apache.http.conn.socket"
-    include_package "org.apache.http.impl"
     include_package "org.apache.http.impl.client"
     include_package "org.apache.http.impl.conn"
     include_package "org.apache.http.entity"
@@ -91,6 +90,7 @@ module Manticore
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
     java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
     java_import "org.apache.http.client.utils.URIBuilder"
+    java_import "org.apache.http.impl.DefaultConnectionReuseStrategy"
     java_import "org.apache.http.impl.auth.BasicScheme"
 
     # This is a class rather than a proc because the proc holds a closure around

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -72,7 +72,6 @@ module Manticore
     include_package "org.apache.http.impl"
     include_package "org.apache.http.impl.client"
     include_package "org.apache.http.impl.conn"
-    include_package "org.apache.http.impl.auth"
     include_package "org.apache.http.entity"
     include_package "org.apache.http.message"
     include_package "org.apache.http.params"
@@ -92,6 +91,7 @@ module Manticore
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
     java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
     java_import "org.apache.http.client.utils.URIBuilder"
+    java_import "org.apache.http.impl.auth.BasicScheme"
 
     # This is a class rather than a proc because the proc holds a closure around
     # the instance of the Client that creates it.


### PR DESCRIPTION
reviewed a few package imports to be explicit about the classes used, 
most interesting is the `org.apache.http.conn.ssl` - [as seen previously](https://github.com/cheald/manticore/issues/87) - there are issues with the dependencies of `org.apache.http.conn.ssl.SSLConnectionSocketFactory` which lead to a `NameError` (not being able to load the class on some JDK setups).

with `include_package` such `NameError` gets lost as it is assumed to be caused by a Java `ClassNotFoundException` but that isn't necessarily always the case. 

by explicitly importing the SSL classes used by manticore's client we should exhibit these failures early (at .rb load time).

