### PR TITLE
CI: Use JRuby 9.2.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - directories:
     - $HOME/.m2
 rvm:
-  - jruby-9.2.15.0 # Ruby 2.5
+  - jruby-9.2.16.0 # Ruby 2.5
 jdk:
   - oraclejdk8
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   - directories:
     - $HOME/.m2
 rvm:
-  - jruby-9.2.14.0 # Ruby 2.5
+  - jruby-9.2.15.0 # Ruby 2.5
 jdk:
   - oraclejdk8
   - openjdk8


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.16.0**.

[JRuby 9.2.16.0 release blog post](https://www.jruby.org/2021/03/03/jruby-9-2-16-0.html)