### PR TITLE
[feat] set Java cause for ManticoreException types

### DIFF
--- a/lib/manticore.rb
+++ b/lib/manticore.rb
@@ -17,7 +17,27 @@ require_relative "./manticore/version"
 # with the beauty of Ruby.
 module Manticore
   # General base class for all Manticore exceptions
-  class ManticoreException < StandardError; end
+  class ManticoreException < StandardError
+    def initialize(arg = nil)
+      case arg
+      when nil
+        @_cause = nil
+        super()
+      when java.lang.Throwable
+        @_cause = arg
+        super(arg.message)
+      else
+        @_cause = nil
+        super(arg)
+      end
+    end
+
+    # @return cause which is likely to be a Java exception
+    # @overload Exception#cause
+    def cause
+      @_cause || super
+    end
+  end
 
   # Exception thrown if you attempt to read from a closed Response stream
   class StreamClosedException < ManticoreException; end

--- a/lib/manticore/response.rb
+++ b/lib/manticore/response.rb
@@ -53,8 +53,9 @@ module Manticore
         ex = Manticore::ConnectTimeout
       rescue Java::JavaNet::SocketException => e
         ex = Manticore::SocketException
-      rescue Java::OrgApacheHttpClient::ClientProtocolException, Java::JavaxNetSsl::SSLHandshakeException, Java::OrgApacheHttpConn::HttpHostConnectException,
-             Java::OrgApacheHttp::NoHttpResponseException, Java::OrgApacheHttp::ConnectionClosedException => e
+      rescue Java::OrgApacheHttpClient::ClientProtocolException, Java::JavaxNetSsl::SSLHandshakeException,
+             Java::OrgApacheHttpConn::HttpHostConnectException, Java::OrgApacheHttp::NoHttpResponseException,
+             Java::OrgApacheHttp::ConnectionClosedException => e
         ex = Manticore::ClientProtocolException
       rescue Java::JavaNet::UnknownHostException => e
         ex = Manticore::ResolutionFailure
@@ -74,7 +75,7 @@ module Manticore
 
       # TODO: If calling async, execute_complete may fail and then silently swallow exceptions. How do we fix that?
       if ex || @exception
-        @exception ||= ex.new(e.cause || e.message)
+        @exception ||= ex.new(e)
         @handlers[:failure].call @exception
         execute_complete
         nil

--- a/lib/manticore/response.rb
+++ b/lib/manticore/response.rb
@@ -62,7 +62,7 @@ module Manticore
       rescue Java::JavaLang::IllegalArgumentException => e
         ex = Manticore::InvalidArgumentException
       rescue Java::JavaLang::IllegalStateException => e
-        if e.message.match(/Connection pool shut down/)
+        if (e.message || '').index('Connection pool shut down')
           ex = Manticore::ClientStoppedException
         else
           @exception = e

--- a/manticore.gemspec
+++ b/manticore.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.3' # JRuby >= 9.1
+
   private_key = File.expand_path("~/.gemcert/gem-private_key.pem")
   if File.exists? private_key
     spec.signing_key = private_key

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -130,7 +130,13 @@ describe Manticore::Client do
         let(:client) { Manticore::Client.new :ssl => {:verify => :strict} }
 
         it "breaks on SSL validation errors" do
-          expect { client.get("https://localhost:55444/").call }.to raise_exception(Manticore::ClientProtocolException)
+          begin
+            client.get("https://localhost:55445/").body
+          rescue Manticore::ClientProtocolException => e
+            expect( e.cause ).to be_a javax.net.ssl.SSLHandshakeException
+          else
+            fail "exception not raised"
+          end
         end
       end
 
@@ -830,7 +836,13 @@ describe Manticore::Client do
     let(:client) { Manticore::Client.new request_timeout: 1, connect_timeout: 1, socket_timeout: 1 }
 
     it "times out" do
-      expect { client.get(local_server "/?sleep=2").body }.to raise_exception(Manticore::SocketTimeout)
+      begin
+        client.get(local_server "/?sleep=2").body
+      rescue Manticore::SocketTimeout => e
+        expect( e.cause ).to be_a java.net.SocketTimeoutException
+      else
+        fail "exception not raised"
+      end
     end
 
     it "times out when custom request options are passed" do

--- a/spec/manticore/response_spec.rb
+++ b/spec/manticore/response_spec.rb
@@ -6,7 +6,7 @@ describe Manticore::Response do
 
   its(:headers) { is_expected.to be_a Hash }
   its(:body) { is_expected.to be_a String }
-  its(:length) { is_expected.to be_a Fixnum }
+  its(:length) { is_expected.to be_a Integer }
 
   it "provides response header lookup via #[]" do
     expect(subject["Content-Type"]).to eq "application/json"


### PR DESCRIPTION
It's very annoying to rescue `ManticoreException` and have a `nil` cause despite these being caused by Java exceptions.
Since Ruby can not fill the `cause` for us (due the way the mapping logic is laid out) let's set the cause manually.