### PR TITLE
Fix SSL handshake hang indefinitely

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -203,11 +203,7 @@ module Manticore
         builder.set_connection_reuse_strategy DefaultConnectionReuseStrategy.new
       end
 
-      socket_config_builder = SocketConfig.custom
-      socket_config_builder.set_so_timeout(options.fetch(:socket_timeout, DEFAULT_SOCKET_TIMEOUT) * 1000)
-      socket_config_builder.set_tcp_no_delay(options.fetch(:tcp_no_delay, true))
-      builder.set_default_socket_config socket_config_builder.build
-
+      builder.set_default_socket_config socket_config_from_options(options)
       builder.set_connection_manager pool(options)
 
       request_config = RequestConfig.custom
@@ -409,9 +405,18 @@ module Manticore
           cm.set_validate_after_inactivity options.fetch(:check_connection_timeout, 2_000)
           cm.set_default_max_per_route options.fetch(:pool_max_per_route, @max_pool_size)
           cm.set_max_total @max_pool_size
+          cm.set_default_socket_config socket_config_from_options(options)
+
           finalize cm, :shutdown
         end
       end
+    end
+    
+    def socket_config_from_options(options)
+      socket_config_builder = SocketConfig.custom
+      socket_config_builder.set_so_timeout(options.fetch(:socket_timeout, DEFAULT_SOCKET_TIMEOUT) * 1000)
+      socket_config_builder.set_tcp_no_delay(options.fetch(:tcp_no_delay, true))
+      socket_config_builder.build
     end
 
     def create_executor_if_needed


### PR DESCRIPTION
There is an [issue](https://issues.apache.org/jira/browse/HTTPCLIENT-1478?focusedCommentId=15998229&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15998229) in apache HTTP client that cause SSL handshake hangs indefinitely.
The issue happens only with proxy server. The socket timeout is unset in the handshake phase.
This commit set the default socket config to PoolingHttpClientConnectionManager explicitly, so the timeout is non zero

Related issue: https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/1033