### PR TITLE
Accept untrusted certs when SSL verify is disabled

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,7 @@ task :generate_certs do
     # Create the CA
     "#{openssl} genrsa 4096 | #{openssl} pkcs8 -topk8 -nocrypt -out #{root}/root-ca.key",
     "#{openssl} req -sha256 -x509 -newkey rsa:4096 -nodes -key #{root}/root-ca.key -sha256 -days 365 -out #{root}/root-ca.crt -subj \"/C=US/ST=The Internet/L=The Internet/O=Manticore CA/OU=Manticore/CN=localhost\"",
+    "#{openssl} req -sha256 -x509 -newkey rsa:4096 -nodes -key #{root}/root-ca.key -sha256 -days 365 -out #{root}/root-untrusted-ca.crt -subj \"/C=US/ST=The Darknet/L=The Darknet/O=Manticore CA/OU=Manticore/CN=localhost\"",
 
     # Create the client CSR, key, and signed cert
     "#{openssl} genrsa 4096 | #{openssl} pkcs8 -topk8 -nocrypt -out #{root}/client.key",
@@ -48,6 +49,7 @@ task :generate_certs do
     "#{openssl} req -sha256 -key #{root}/host.key -newkey rsa:4096 -out #{root}/host.csr -subj \"/C=US/ST=The Internet/L=The Internet/O=Manticore Host/OU=Manticore/CN=localhost\"",
     "#{openssl} x509 -req -in #{root}/host.csr -CA #{root}/root-ca.crt -CAkey #{root}/root-ca.key -CAcreateserial -out #{root}/host.crt -sha256 -days 1",
     "#{openssl} x509 -req -in #{root}/host.csr -CA #{root}/root-ca.crt -CAkey #{root}/root-ca.key -CAcreateserial -out #{root}/host-expired.crt -sha256 -days -7",
+    "#{openssl} x509 -req -in #{root}/host.csr -CA #{root}/root-untrusted-ca.crt -CAkey #{root}/root-ca.key -CAcreateserial -out #{root}/host-untrusted.crt -sha256 -days 1",
 
     "#{keytool} -import -file #{root}/root-ca.crt -alias rootCA -keystore #{root}/truststore.jks -noprompt -storepass test123",
     "#{openssl} pkcs12 -export -clcerts -out #{root}/client.p12 -inkey #{root}/client.key -in #{root}/client.crt -certfile #{root}/root-ca.crt -password pass:test123",

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -88,10 +88,19 @@ module Manticore
     java_import "org.apache.http.auth.UsernamePasswordCredentials"
     java_import "org.apache.http.conn.ssl.SSLConnectionSocketFactory"
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
-    java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
     java_import "org.apache.http.client.utils.URIBuilder"
     java_import "org.apache.http.impl.DefaultConnectionReuseStrategy"
     java_import "org.apache.http.impl.auth.BasicScheme"
+
+    # Copied from: https://github.com/apache/httpcomponents-client/blob/0a42d173ef7ae4497439cf52d75d43ef51e46541/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
+    # Which can be used directly once this is merged: https://github.com/cheald/manticore/pull/99
+    class TrustAllStrategy
+      INSTANCE = new
+
+      def isTrusted(*)
+        true
+      end
+    end
 
     # This is a class rather than a proc because the proc holds a closure around
     # the instance of the Client that creates it.
@@ -615,7 +624,7 @@ module Manticore
       case ssl_options.fetch(:verify, :strict)
       when false, :disable, :none
         trust_store = nil
-        trust_strategy = TrustSelfSignedStrategy.new
+        trust_strategy = TrustAllStrategy::INSTANCE
         verifier = SSLConnectionSocketFactory::ALLOW_ALL_HOSTNAME_VERIFIER
       when :browser
         verifier = SSLConnectionSocketFactory::BROWSER_COMPATIBLE_HOSTNAME_VERIFIER

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -101,6 +101,10 @@ describe Manticore::Client do
       it "does not break on SSL validation errors" do
         expect { client.get("https://localhost:55444/").body }.to_not raise_exception
       end
+
+      it "does not break on untrusted certificates" do
+        expect { client.get("https://localhost:55447/").body }.to_not raise_exception
+      end
     end
 
     context "when off" do
@@ -232,6 +236,10 @@ describe Manticore::Client do
 
         it "does not break on expired SSL certificates" do
           expect { client.get("https://localhost:55446/").body }.to_not raise_exception
+        end
+
+        it "does not break on untrusted certificates" do
+          expect { client.get("https://localhost:55447/").body }.to_not raise_exception
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,6 +151,7 @@ RSpec.configure do |c|
     start_ssl_server 55444
     start_ssl_server 55445, :SSLVerifyClient => OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT, :SSLCACertificateFile => File.expand_path("../ssl/root-ca.crt", __FILE__)
     start_ssl_server 55446, cert: File.expand_path("../ssl/host-expired.crt", __FILE__)
+    start_ssl_server 55447, cert: File.expand_path("../ssl/host-untrusted.crt", __FILE__), SSLCACertificateFile: File.expand_path("../ssl/root-untrusted-ca.crt", __FILE__)
 
     Manticore.disable_httpcomponents_logging!
   }


### PR DESCRIPTION
`TrustSelfSignedStrategy` only allows self-signed certificates by
checking that the chain length is 1. This doesn't work for certificates
that are signed by an untrusted CA. Newer versions of httpclient (>=
4.5.4) provide `TrustAllStrategy`, which returns true for all
certificate chains. That won't be available until
https://github.com/cheald/manticore/pull/99 is merged, so this copies
the implementation and uses it when SSL verification is disabled.