### PR TITLE
[feat] restore compat with (legacy) verify: false

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -88,19 +88,10 @@ module Manticore
     java_import "org.apache.http.auth.UsernamePasswordCredentials"
     java_import "org.apache.http.conn.ssl.SSLConnectionSocketFactory"
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
+    java_import "org.apache.http.conn.ssl.TrustAllStrategy"
     java_import "org.apache.http.client.utils.URIBuilder"
     java_import "org.apache.http.impl.DefaultConnectionReuseStrategy"
     java_import "org.apache.http.impl.auth.BasicScheme"
-
-    # Copied from: https://github.com/apache/httpcomponents-client/blob/0a42d173ef7ae4497439cf52d75d43ef51e46541/httpclient5/src/main/java/org/apache/hc/client5/http/ssl/TrustAllStrategy.java
-    # Which can be used directly once this is merged: https://github.com/cheald/manticore/pull/99
-    class TrustAllStrategy
-      INSTANCE = new
-
-      def isTrusted(*)
-        true
-      end
-    end
 
     # This is a class rather than a proc because the proc holds a closure around
     # the instance of the Client that creates it.

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -89,6 +89,7 @@ module Manticore
     java_import "org.apache.http.conn.ssl.SSLConnectionSocketFactory"
     java_import "org.apache.http.conn.ssl.SSLContextBuilder"
     java_import "org.apache.http.conn.ssl.TrustAllStrategy"
+    java_import "org.apache.http.conn.ssl.TrustSelfSignedStrategy"
     java_import "org.apache.http.client.utils.URIBuilder"
     java_import "org.apache.http.impl.DefaultConnectionReuseStrategy"
     java_import "org.apache.http.impl.auth.BasicScheme"
@@ -611,9 +612,12 @@ module Manticore
     def ssl_socket_factory_from_options(ssl_options)
       trust_store = trust_strategy = nil
 
-      verifier = SSLConnectionSocketFactory::STRICT_HOSTNAME_VERIFIER
       case ssl_options.fetch(:verify, :strict)
-      when false, :disable, :none
+      when false
+        trust_store = nil
+        trust_strategy = TrustSelfSignedStrategy::INSTANCE
+        verifier = SSLConnectionSocketFactory::ALLOW_ALL_HOSTNAME_VERIFIER
+      when :disable, :none
         trust_store = nil
         trust_strategy = TrustAllStrategy::INSTANCE
         verifier = SSLConnectionSocketFactory::ALLOW_ALL_HOSTNAME_VERIFIER

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -101,10 +101,6 @@ describe Manticore::Client do
       it "does not break on SSL validation errors" do
         expect { client.get("https://localhost:55444/").body }.to_not raise_exception
       end
-
-      it "does not break on untrusted certificates" do
-        expect { client.get("https://localhost:55447/").body }.to_not raise_exception
-      end
     end
 
     context "when off" do


### PR DESCRIPTION
`verify: :disabled` still disables all verification as expected, 
the (deprecated) `verify: false` stays as in < **0.8** (before #100)