### PR TITLE
ssl[:trust_strategy]: wrapper for org.apache.http.conn.ssl.TrustStrategy

### DIFF
--- a/lib/manticore.rb
+++ b/lib/manticore.rb
@@ -67,6 +67,7 @@ module Manticore
 
   require_relative "./manticore/java_extensions"
   require_relative "./manticore/client/proxies"
+  require_relative "./manticore/client/trust_strategies"
   require_relative "./manticore/client"
   require_relative "./manticore/response"
   require_relative "./manticore/stubbed_response"

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -166,6 +166,8 @@ module Manticore
     #                                                                            cause Manticore to accept a certificate for *.foo.com for all subdomains and sub-subdomains (eg a.b.foo.com).
     #                                                                            The default `:strict` is like `:browser` except it'll only accept a single level of subdomains for wildcards,
     #                                                                            eg `b.foo.com` will be accepted for a `*.foo.com` certificate, but `a.b.foo.com` will not be.
+    # @option options [Client::TrustStrategiesInterface] ssl[:trust_strategy] (nil)     A trust strategy to use in addition to any built by `ssl[:verify]`.
+    #                                                                                                @see Client::TrustStrategiesInterface#coerce
     # @option options [String]          ssl[:truststore]          (nil)        Path to a custom trust store to use the verifying SSL connections
     # @option options [String]          ssl[:truststore_password] (nil)        Password used for decrypting the server trust store
     # @option options [String]          ssl[:truststore_type]     (nil)        Format of the trust store, ie "JKS" or "PKCS12". If left nil, the type will be inferred from the truststore filename.
@@ -627,6 +629,10 @@ module Manticore
         verifier = SSLConnectionSocketFactory::STRICT_HOSTNAME_VERIFIER
       else
         raise "Invalid value for :verify. Valid values are (:all, :browser, :default)"
+      end
+
+      if ssl_options.include?(:trust_strategy)
+        trust_strategy = TrustStrategiesInterface.combine(trust_strategy, ssl_options.fetch(:trust_strategy))
       end
 
       context = SSLContextBuilder.new

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -632,7 +632,7 @@ module Manticore
       end
 
       if ssl_options.include?(:trust_strategy)
-        trust_strategy = TrustStrategiesInterface.combine(trust_strategy, ssl_options.fetch(:trust_strategy))
+        trust_strategy = TrustStrategies.combine(trust_strategy, ssl_options.fetch(:trust_strategy))
       end
 
       context = SSLContextBuilder.new

--- a/lib/manticore/client/trust_strategies.rb
+++ b/lib/manticore/client/trust_strategies.rb
@@ -1,0 +1,101 @@
+module Manticore
+  class Client
+    module TrustStrategiesInterface
+      java_import org.apache.http.conn.ssl.TrustStrategy
+      include TrustStrategy
+
+      # Coerces to org.apache.http.conn.ssl.TrustStrategy, allowing nil pass-through
+      #
+      # @overload coerce(coercible)
+      #   @param coercible [nil|TrustStrategy]
+      #   @return [nil,TrustStrategy]
+      # @overload coerce(coercible)
+      #   @param coercible [Proc<(Array<OpenSSL::X509::Certificate>,String)>:Boolean]
+      #     A proc that accepts two arguments and returns a boolean value.
+      #     Expects a proc that operates on a pair of parameters:
+      #       @param cert_chain [Enumerable<OpenSSL::X509::Certificate>]: the peer's certificate chain
+      #       @param auth_type [String]: the authentication type based on the client certificate
+      #       @return [Boolean]: true if the certificate can be trusted without verification by the trust manager,
+      #                        false otherwise.
+      #   @example: CA Trusted Fingerprint
+      #      ca_trusted_fingerprint = lambda do |cert_chain, type|
+      #        cert_chain.lazy
+      #                  .map(&:to_der)
+      #                  .map(&::Digest::SHA256.method(:hexdigest))
+      #                  .include?("324a87eebb19265ffb675dc345eb0f3b5d9de3f015159227a00fe552291d4cc4")
+      #      end
+      #      TrustStrategiesInterface.coerce(ca_trusted_fingerprint)
+      def self.coerce(coercible)
+        case coercible
+        when TrustStrategy, nil then coercible
+        when ::Proc             then CustomTrustStrategy.new(coercible)
+        else fail(ArgumentError, "No implicit conversion of #{coercible} to #{self}")
+        end
+      end
+
+      # Combines two possibly-nil TrustStrategiesInterface-coercible objects into a
+      # single TrustStrategy, or to nil if both are nil.
+      #
+      # @param lhs [nil|TrustStrategiesInterface]
+      # @param rhs [nil|TrustStrategiesInterface]
+      # @return [nil,TrustStrategiesInterface]
+      def self.combine(lhs, rhs)
+        return coerce(rhs) if lhs.nil?
+        return coerce(lhs) if rhs.nil?
+
+        CombinedTrustStrategy.new(lhs,rhs)
+      end
+    end
+
+    ##
+    # @api private
+    # A CombinedTrustStrategy can be used to bypass the Trust Manager if
+    # *EITHER* TrustStrategy trusts the provided certificate chain.
+    class CombinedTrustStrategy
+      include TrustStrategiesInterface
+
+      ##
+      # @api private
+      # @see TrustStrategiesInterface::combine
+      def initialize(lhs, rhs)
+        @lhs = lhs
+        @rhs = rhs
+        super()
+      end
+
+      def trusted?(chain, type)
+        @lhs.trusted?(chain, type) || @rhs.trusted?(chain, type)
+      end
+    end
+
+
+    ##
+    # @api private
+    # A CustomTrustStrategy is an org.apache.http.conn.ssl.TrustStrategy
+    # defined with a proc that uses Ruby OpenSSL::X509::Certificates
+    # @see TrustStrategiesInterface::coerce(Proc)
+    class CustomTrustStrategy
+      include TrustStrategiesInterface
+
+      ##
+      # @see TrustStrategiesInterface.coerce(Proc)
+      def initialize(proc)
+        fail(ArgumentError, "2-arity proc required") unless proc.arity == 2
+        @trust_strategy = proc
+      end
+
+      CONVERT_JAVA_CERTIFICATE_TO_RUBY = -> (java_cert) { ::OpenSSL::X509::Certificate.new(java_cert.encoded) }
+      private_constant :CONVERT_JAVA_CERTIFICATE_TO_RUBY
+
+      def trusted?(java_chain, type)
+        return !!@trust_strategy.call(java_chain.lazy.map(&CONVERT_JAVA_CERTIFICATE_TO_RUBY), type)
+      end
+
+      private
+
+      def ruby_cert(java_cert)
+        ::OpenSSL::X509::Certificate.new(java_cert.encoded)
+      end
+    end
+  end
+end

--- a/lib/manticore/client/trust_strategies.rb
+++ b/lib/manticore/client/trust_strategies.rb
@@ -1,9 +1,9 @@
 module Manticore
   class Client
-    module TrustStrategiesInterface
-      java_import org.apache.http.conn.ssl.TrustStrategy
-      include TrustStrategy
-
+    ##
+    # TrustStrategies is a utility module that provides helpers for
+    # working with org.apache.http.conn.ssl.TrustStrategy
+    module TrustStrategies
       # Coerces to org.apache.http.conn.ssl.TrustStrategy, allowing nil pass-through
       #
       # @overload coerce(coercible)
@@ -11,12 +11,13 @@ module Manticore
       #   @return [nil,TrustStrategy]
       # @overload coerce(coercible)
       #   @param coercible [Proc<(Array<OpenSSL::X509::Certificate>,String)>:Boolean]
-      #     A proc that accepts two arguments and returns a boolean value.
-      #     Expects a proc that operates on a pair of parameters:
+      #     A proc that accepts two arguments and returns a boolean value, and is effectively a
+      #     Ruby-native implementation of `org.apache.http.conn.ssl.TrustStrategy#isTrusted`.
       #       @param cert_chain [Enumerable<OpenSSL::X509::Certificate>]: the peer's certificate chain
       #       @param auth_type [String]: the authentication type based on the client certificate
+      #       @raise [OpenSSL::X509::CertificateError]: thrown if the certificate is not trusted or invalid
       #       @return [Boolean]: true if the certificate can be trusted without verification by the trust manager,
-      #                        false otherwise.
+      #                          false otherwise.
       #   @example: CA Trusted Fingerprint
       #      ca_trusted_fingerprint = lambda do |cert_chain, type|
       #        cert_chain.lazy
@@ -24,26 +25,26 @@ module Manticore
       #                  .map(&::Digest::SHA256.method(:hexdigest))
       #                  .include?("324a87eebb19265ffb675dc345eb0f3b5d9de3f015159227a00fe552291d4cc4")
       #      end
-      #      TrustStrategiesInterface.coerce(ca_trusted_fingerprint)
+      #      TrustStrategies.coerce(ca_trusted_fingerprint)
       def self.coerce(coercible)
         case coercible
-        when TrustStrategy, nil then coercible
-        when ::Proc             then CustomTrustStrategy.new(coercible)
+        when org.apache.http.conn.ssl.TrustStrategy, nil then coercible
+        when ::Proc                                      then CustomTrustStrategy.new(coercible)
         else fail(ArgumentError, "No implicit conversion of #{coercible} to #{self}")
         end
       end
 
-      # Combines two possibly-nil TrustStrategiesInterface-coercible objects into a
-      # single TrustStrategy, or to nil if both are nil.
+      # Combines two possibly-nil TrustStrategies-coercible objects into a
+      # single org.apache.http.conn.ssl.TrustStrategy, or to nil if both are nil.
       #
-      # @param lhs [nil|TrustStrategiesInterface]
-      # @param rhs [nil|TrustStrategiesInterface]
-      # @return [nil,TrustStrategiesInterface]
+      # @param lhs [nil|TrustStrategie#coerce]
+      # @param rhs [nil|TrustStrategies#coerce]
+      # @return [nil,org.apache.http.conn.ssl.TrustStrategy]
       def self.combine(lhs, rhs)
         return coerce(rhs) if lhs.nil?
         return coerce(lhs) if rhs.nil?
 
-        CombinedTrustStrategy.new(lhs,rhs)
+        CombinedTrustStrategy.new(coerce(lhs), coerce(rhs))
       end
     end
 
@@ -51,18 +52,21 @@ module Manticore
     # @api private
     # A CombinedTrustStrategy can be used to bypass the Trust Manager if
     # *EITHER* TrustStrategy trusts the provided certificate chain.
+    # @see TrustStrategies::combine
     class CombinedTrustStrategy
-      include TrustStrategiesInterface
+      include org.apache.http.conn.ssl.TrustStrategy
 
       ##
       # @api private
-      # @see TrustStrategiesInterface::combine
+      # @see TrustStrategies::combine
       def initialize(lhs, rhs)
         @lhs = lhs
         @rhs = rhs
         super()
       end
 
+      ##
+      # @override (see org.apache.http.conn.ssl.TrustStrategy#isTrusted)
       def trusted?(chain, type)
         @lhs.trusted?(chain, type) || @rhs.trusted?(chain, type)
       end
@@ -73,12 +77,12 @@ module Manticore
     # @api private
     # A CustomTrustStrategy is an org.apache.http.conn.ssl.TrustStrategy
     # defined with a proc that uses Ruby OpenSSL::X509::Certificates
-    # @see TrustStrategiesInterface::coerce(Proc)
+    # @see TrustStrategies::coerce(Proc)
     class CustomTrustStrategy
-      include TrustStrategiesInterface
+      include org.apache.http.conn.ssl.TrustStrategy
 
       ##
-      # @see TrustStrategiesInterface.coerce(Proc)
+      # @see TrustStrategies.coerce(Proc)
       def initialize(proc)
         fail(ArgumentError, "2-arity proc required") unless proc.arity == 2
         @trust_strategy = proc
@@ -87,14 +91,12 @@ module Manticore
       CONVERT_JAVA_CERTIFICATE_TO_RUBY = -> (java_cert) { ::OpenSSL::X509::Certificate.new(java_cert.encoded) }
       private_constant :CONVERT_JAVA_CERTIFICATE_TO_RUBY
 
+      ##
+      # @override (see org.apache.http.conn.ssl.TrustStrategy#isTrusted)
       def trusted?(java_chain, type)
-        return !!@trust_strategy.call(java_chain.lazy.map(&CONVERT_JAVA_CERTIFICATE_TO_RUBY), type)
-      end
-
-      private
-
-      def ruby_cert(java_cert)
-        ::OpenSSL::X509::Certificate.new(java_cert.encoded)
+        @trust_strategy.call(java_chain.lazy.map(&CONVERT_JAVA_CERTIFICATE_TO_RUBY), String.new(type))
+      rescue OpenSSL::X509::CertificateError => e
+        raise(java.security.cert.CertificateException.new(e.to_java(java.lang.Throwable)))
       end
     end
   end

--- a/spec/manticore/client_trust_strategies_spec.rb
+++ b/spec/manticore/client_trust_strategies_spec.rb
@@ -1,0 +1,168 @@
+# encoding: utf-8
+require "spec_helper"
+describe Manticore::Client::TrustStrategies do
+  describe '#coerce' do
+    subject(:coerced) { described_class.coerce(input) }
+    context 'with a nil value' do
+      let(:input) { nil }
+      it 'returns the value unchanged' do
+        expect(coerced).to be_nil
+      end
+    end
+    context 'with an implementation of org.apache.http.conn.ssl.TrustStrategy' do
+      let(:input) { org.apache.http.conn.ssl.TrustAllStrategy::INSTANCE }
+      it 'returns the value unchanged' do
+        expect(coerced).to be input
+      end
+    end
+    context 'with a Proc' do
+      let(:input) { ->(chain, type) { true } }
+      it 'wraps the proc in a `CustomTrustStrategy`' do
+        expect(Manticore::Client::CustomTrustStrategy).to receive(:new).with(input).and_call_original
+        expect(described_class.coerce(input)).to be_a_kind_of Manticore::Client::CustomTrustStrategy
+      end
+    end
+  end
+
+  describe '#combine' do
+    context 'when left-hand value is nil' do
+      let(:left_hand_strategy) { nil }
+      let(:right_hand_strategy) { described_class.coerce(->(chain,type){ true }) }
+      it 'returns the right-hand value coerced' do
+        expect(described_class).to receive(:coerce).with(right_hand_strategy).and_call_original
+        expect(described_class.combine(left_hand_strategy, right_hand_strategy)).to be right_hand_strategy
+      end
+    end
+    context 'when the right-hand value is nil' do
+      let(:left_hand_strategy) {  described_class.coerce(->(chain,type){ true }) }
+      let(:right_hand_strategy) { nil }
+      it 'returns the left-hand value coerced' do
+        expect(described_class).to receive(:coerce).with(left_hand_strategy).and_call_original
+        expect(described_class.combine(left_hand_strategy, right_hand_strategy)).to be left_hand_strategy
+      end
+    end
+    context 'when neither value is nil' do
+      let(:left_hand_strategy) {  described_class.coerce(->(chain,type){ true }) }
+      let(:right_hand_strategy) { described_class.coerce(->(chain,type){ true }) }
+
+      it 'returns a CombinedTrustStrategy' do
+        expect(Manticore::Client::CombinedTrustStrategy)
+          .to receive(:new).with(left_hand_strategy, right_hand_strategy).and_call_original
+
+        # ensures that the values are coerced.
+        expect(described_class).to receive(:coerce).with(left_hand_strategy).and_call_original
+        expect(described_class).to receive(:coerce).with(right_hand_strategy).and_call_original
+
+        combined = described_class.combine(left_hand_strategy, right_hand_strategy)
+        expect(combined).to be_a_kind_of Manticore::Client::CombinedTrustStrategy
+      end
+    end
+    context 'when both values are nil' do
+      let(:left_hand_strategy) { nil }
+      let(:right_hand_strategy) { nil }
+
+      it 'returns nil' do
+        expect(described_class.combine(left_hand_strategy, right_hand_strategy)).to be nil
+      end
+    end
+  end
+end
+
+describe Manticore::Client::CustomTrustStrategy do
+
+  subject(:custom_trust_strategy) { described_class.new(trust_strategy_proc) }
+
+  context 'when called via Java interface' do
+    def load_java_cert(file_path)
+      pem_contents = File.read(file_path)
+      cf = java.security.cert.CertificateFactory::getInstance("X.509")
+      is = java.io.ByteArrayInputStream.new(pem_contents.to_java_bytes)
+      cf.generateCertificate(is)
+    end
+
+    let(:java_host_cert) { load_java_cert(File.expand_path("../../ssl/host.crt", __FILE__)) }
+    let(:java_root_cert) { load_java_cert(File.expand_path("../../ssl/root-ca.crt", __FILE__)) }
+    let(:java_chain) { [java_host_cert, java_root_cert].to_java(java.security.cert.X509Certificate) }
+    let(:java_type) { java.lang.String.new("my_type".to_java_bytes) }
+
+    subject(:java_trust_strategy) { custom_trust_strategy.to_java(org.apache.http.conn.ssl.TrustStrategy) }
+
+    context 'when called with Java Certs and a Java String' do
+      let(:trust_strategy_proc) { ->(chain,type) { true } }
+      it 'yields an enum of equivalent Ruby certs and an equivalent Ruby String' do
+        expect(trust_strategy_proc).to receive(:call) do |chain, type|
+          expect(chain.to_a.length).to eq java_chain.length
+          chain.each_with_index do |cert, idx|
+            expect(cert).to be_a_kind_of OpenSSL::X509::Certificate
+            expect(cert.to_der).to eq String.from_java_bytes(java_chain[idx].encoded)
+          end
+          expect(type).to be_a_kind_of String
+          expect(type).to eq String.from_java_bytes(java_type.bytes)
+        end
+
+        expect(java_trust_strategy.isTrusted(java_chain, java_type)).to be true
+      end
+    end
+
+    context 'when the ruby block returns false' do
+      let(:trust_strategy_proc) { ->(chain,type) { false } }
+      it 'returns false' do
+        expect(java_trust_strategy.isTrusted(java_chain, java_type)).to be false
+      end
+    end
+
+    context 'when the ruby block returns true' do
+      let(:trust_strategy_proc) { ->(chain,type) { true } }
+      it 'returns true' do
+        expect(java_trust_strategy.isTrusted(java_chain, java_type)).to be true
+      end
+    end
+
+    context 'when the ruby block raises an exception' do
+      let(:trust_strategy_proc) { ->(chain, type) { fail(OpenSSL::X509::CertificateError, 'intentional') } }
+      it 'throws a CertificateException' do
+        expect {
+          java_trust_strategy.isTrusted(java_chain, java_type)
+        }.to raise_exception(java.security.cert.CertificateException)
+      end
+    end
+  end
+end
+
+describe Manticore::Client::CombinedTrustStrategy do
+  let(:always_trust_strategy) { ->(chain,type) { true } }
+  let(:never_trust_strategy) { ->(chain,type) { false } }
+
+  subject(:combined_trust_strategy) { Manticore::Client::TrustStrategies.combine(left_hand_strategy, right_hand_strategy) }
+
+  context 'when left-hand strategy trusts' do
+    let(:left_hand_strategy) { always_trust_strategy }
+    context 'when right-hand strategy trusts' do
+      let(:right_hand_strategy) { always_trust_strategy }
+      it 'trusts' do
+        expect(combined_trust_strategy.trusted?([],'ignored')).to be true
+      end
+    end
+    context 'when right-hand strategy does not trust' do
+      let(:right_hand_strategy) { never_trust_strategy }
+      it 'trusts' do
+        expect(combined_trust_strategy.trusted?([],'ignored')).to be true
+      end
+    end
+  end
+  context 'when left-hand strategy does not trust' do
+    let(:left_hand_strategy) { never_trust_strategy }
+    context 'when right-hand strategy trusts' do
+      let(:right_hand_strategy) { always_trust_strategy }
+      it 'trusts' do
+        expect(combined_trust_strategy.trusted?([],'ignored')).to be true
+      end
+    end
+    context 'when right-hand strategy does not trust' do
+      let(:right_hand_strategy) { never_trust_strategy }
+      it 'does not trust' do
+        expect(combined_trust_strategy.trusted?([],'ignored')).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an advanced feature so consumers of this library can provide their own
TrustStrategy to refine the situations where the TrustManager can be bypassed.

Consumers can pass either native java implementations of TrustStrategy, or a
ruby-defined Proc that is expected to handle ruby-OpenSSL X509 Certificates.

Works with the trust_strategy that is possibly instantiated with some
values of `ssl[:verify]` to produce a _combined_ TrustStrategy that will
bypass the TrustManager if _any_ of the configured trust strategies indicate
that the cert chain qualifies for a bypass.