### PR TITLE
ssl[:verify]: Add :noop option to turn off only the hostname verification

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -183,9 +183,9 @@ module Manticore
     #                                                                            cause Manticore to accept a certificate for *.foo.com for all subdomains and sub-subdomains (eg a.b.foo.com).
     #                                                                            The default `:default` is like `:browser` but more strict - only accepts a single level of subdomains for wildcards,
     #                                                                            eg `b.foo.com` will be accepted for a `*.foo.com` certificate, but `a.b.foo.com` will not be. Set to `:noop` to
-    #                                                                            to turn off hostname verification, unlike :none, this option still validates the certificate.
-    # @option options [Client::TrustStrategiesInterface] ssl[:trust_strategy] (nil)     A trust strategy to use in addition to any built by `ssl[:verify]`.
-    #                                                                                                @see Client::TrustStrategiesInterface#coerce
+    #                                                                            turn off hostname verification, unlike :none, this option still validates the certificate.
+    # @option options [Client::TrustStrategies] ssl[:trust_strategy] (nil)     A trust strategy to use in addition to any built by `ssl[:verify]`.
+    #                                                                                                @see Client::TrustStrategies#coerce
     # @option options [String]          ssl[:truststore]          (nil)        Path to a custom trust store to use the verifying SSL connections
     # @option options [String]          ssl[:truststore_password] (nil)        Password used for decrypting the server trust store
     # @option options [String]          ssl[:truststore_type]     (nil)        Format of the trust store, ie "JKS" or "PKCS12". If left nil, the type will be inferred from the truststore filename.

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -182,7 +182,8 @@ module Manticore
     # @option options [Symbol]          ssl[:verify]               (:default)  Hostname verification setting. Set to `:none` to turn off hostname verification. Setting to `:browser` will
     #                                                                            cause Manticore to accept a certificate for *.foo.com for all subdomains and sub-subdomains (eg a.b.foo.com).
     #                                                                            The default `:default` is like `:browser` but more strict - only accepts a single level of subdomains for wildcards,
-    #                                                                            eg `b.foo.com` will be accepted for a `*.foo.com` certificate, but `a.b.foo.com` will not be.
+    #                                                                            eg `b.foo.com` will be accepted for a `*.foo.com` certificate, but `a.b.foo.com` will not be. Set to `:noop` to
+    #                                                                            to turn off hostname verification, unlike :none, this option still validates the certificate.
     # @option options [Client::TrustStrategiesInterface] ssl[:trust_strategy] (nil)     A trust strategy to use in addition to any built by `ssl[:verify]`.
     #                                                                                                @see Client::TrustStrategiesInterface#coerce
     # @option options [String]          ssl[:truststore]          (nil)        Path to a custom trust store to use the verifying SSL connections
@@ -680,8 +681,10 @@ module Manticore
         verifier = DefaultHostnameVerifier.new
       when :strict # compatibility
         verifier = SSLConnectionSocketFactory::STRICT_HOSTNAME_VERIFIER
+      when :noop
+        verifier = NoopHostnameVerifier::INSTANCE
       else
-        raise "Invalid value for :verify. Valid values are (:default, :browser, :none)"
+        raise "Invalid value for :verify. Valid values are (:default, :browser, :noop, :none)"
       end
 
       if ssl_options.include?(:trust_strategy)

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -312,6 +312,24 @@ describe Manticore::Client do
           end
         end
       end
+
+      context "when noop" do
+        let(:client) { Manticore::Client.new :ssl => {verify: :noop, ca_file: File.expand_path("../../ssl/root-ca.crt", __FILE__)} }
+        let(:hostname_verifier) { Proc.new { |hostname, session| true } }
+
+        context "and hostname mismatch the certificate CN" do
+          it "request and succeed" do
+            # 127.0.0.1 was used on purpose here so it's mismatch the certificate's CN localhost
+            expect { client.get("https://127.0.0.1:55444/").body }.to_not raise_exception
+          end
+
+          context "and the server SSL certificate is expired" do
+            it "request and fail" do
+              expect { client.get("https://127.0.0.1:55446/").body }.to raise_exception(Manticore::ClientProtocolException)
+            end
+          end
+        end
+      end
     end
 
     describe ":cipher_suites" do


### PR DESCRIPTION
Added an `ssl[:verify]` option `:noop` to turn off only the hostname verification, unlike `:none` or `:disabled`, this new option still validates the certificate, ignoring only the hostname verification. 