### PR TITLE
Raises InvalidUriException for java URISyntaxException

### DIFF
--- a/lib/manticore.rb
+++ b/lib/manticore.rb
@@ -54,6 +54,9 @@ module Manticore
   # The client has been closed so it's no longer usable
   class ClientStoppedException < ManticoreException; end
 
+  # Client tried to use illegal characters in URI
+  class InvalidUriException < ManticoreException; end
+
   # Socket breaks, etc
   class SocketException < ManticoreException; end
 

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -81,7 +81,6 @@ module Manticore
     include_package "java.security.spec"
     include_package "java.security"
     java_import "org.apache.http.HttpHost"
-    java_import "java.net.URISyntaxException"
     java_import "javax.net.ssl.SSLContext"
     java_import "org.manticore.HttpGetWithEntity"
     java_import "org.manticore.HttpDeleteWithEntity"

--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -81,6 +81,7 @@ module Manticore
     include_package "java.security.spec"
     include_package "java.security"
     java_import "org.apache.http.HttpHost"
+    java_import "java.net.URISyntaxException"
     java_import "javax.net.ssl.SSLContext"
     java_import "org.manticore.HttpGetWithEntity"
     java_import "org.manticore.HttpDeleteWithEntity"
@@ -515,7 +516,11 @@ module Manticore
 
     def uri_from_url_and_options(url, options)
       url = url.to_s if url.is_a?(URI)
-      builder = URIBuilder.new(url)
+      begin
+        builder = URIBuilder.new(url)
+      rescue Java::JavaNet::URISyntaxException => e
+        raise Manticore::InvalidUriException.new(e)
+      end
       pairs = struct_to_name_value_pairs(options[:query])
       builder.add_parameters pairs unless pairs.empty?
       builder.to_string

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -538,6 +538,11 @@ describe Manticore::Client do
       j = JSON.load(response.body)
       expect(CGI.parse j["uri"]["query"]).to eq({"foo" => ["bar"], "baz" => ["bin"]})
     end
+
+    it "raises InvalidUriException for illegal character in URI" do
+      expect { client.get(local_server + "?foo=bar{{{", query: {"baz" => "bin"})}
+        .to raise_exception(Manticore::InvalidUriException)
+    end
   end
 
   describe "#post" do


### PR DESCRIPTION
Currently if we use  illegal characters in uri example `https://www.google.com?q=baz{{||  ` which fails with java.net.URISyntaxException. This pr provided wrapper around java exception to handle uri syntax exception.