### PR TITLE
Don't strip the decoded certificate, chomp should be enough

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -745,7 +745,7 @@ module Manticore
         key_parts = key_str.scan(KEY_EXTRACTION_REGEXP)
         key_parts.each do |type, b64key|
           body = Base64.decode64 b64key
-          spec = PKCS8EncodedKeySpec.new(body.strip.to_java_bytes)
+          spec = PKCS8EncodedKeySpec.new(body.chomp.to_java_bytes)
           type = type.strip
           type = "RSA" if type == ""
           key = KeyFactory.getInstance(type).generatePrivate(spec)

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -257,7 +257,7 @@ describe Manticore::Client do
           )
         end
 
-        it 'doesn\'t throw an Exception' do
+        it 'raises no exception' do
           expect(client).not_to be_nil
         end
       end

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -245,6 +245,23 @@ describe Manticore::Client do
         end
       end
 
+      context 'when client_key ending on whitespace character' do
+        let(:client) do
+          Manticore::Client.new(
+            ssl: {
+              verify: :default,
+              ca_file: File.expand_path('../ssl/root-ca.crt', __dir__),
+              client_cert: File.read(File.expand_path('../ssl/client_whitespace.crt', __dir__)),
+              client_key: File.read(File.expand_path('../ssl/client_whitespace.key', __dir__))
+            }
+          )
+        end
+
+        it 'doesn\'t throw an Exception' do
+          expect(client).not_to be_nil
+        end
+      end
+
       context "when off" do
         let(:client) { Manticore::Client.new :ssl => {:verify => :disable} }
 


### PR DESCRIPTION
Strip removes all whitespace characters, not just line breaks and spaces (null, horizontal tab, line feed, vertical tab, form feed, carriage return, space). If a certificate ends with such a character, a Java::JavaSecuritySpec::InvalidKeySpecException is thrown. For example, this [issue](https://github.com/logstash-plugins/logstash-output-http/issues/92) results from this bug.