### PR TITLE
don't send entity when get/delete have no body

### DIFF
--- a/lib/manticore/client.rb
+++ b/lib/manticore/client.rb
@@ -261,7 +261,8 @@ module Manticore
     # @macro http_method_shared_sync
     def get(url, options = {}, &block)
       options = treat_params_as_query(options)
-      request HttpGetWithEntity, url, options, &block
+      get_class = options[:body] ? HttpGetWithEntity : HttpGet
+      request get_class, url, options, &block
     end
 
     # Perform a HTTP PUT request
@@ -287,7 +288,8 @@ module Manticore
     # @macro http_method_shared_sync
     def delete(url, options = {}, &block)
       options = treat_params_as_query(options)
-      request HttpDeleteWithEntity, url, options, &block
+      delete_class = options[:body] ? HttpDeleteWithEntity : HttpDelete
+      request delete_class, url, options, &block
     end
 
     # Perform a HTTP OPTIONS request

--- a/spec/manticore/client_spec.rb
+++ b/spec/manticore/client_spec.rb
@@ -533,14 +533,14 @@ describe Manticore::Client do
     it "can send an array of parameters as :params" do
       response = client.get(local_server, params: {"foo" => ["baz", "bar"], "bar" => {"baz" => ["bin", 1, :b]}})
       j = JSON.load(response.body)
-      expect(j["body"]).to eq ""
+      expect(j["body"]).to be_nil
       expect(j["uri"]["query"]).to include("foo=baz")
     end
 
     it "can send an array of parameters as :query" do
       response = client.get(local_server, query: {"foo" => ["baz", "bar"]})
       j = JSON.load(response.body)
-      expect(j["body"]).to eq ""
+      expect(j["body"]).to be_nil
       expect(j["uri"]["query"]).to include("foo=baz")
     end
 
@@ -559,6 +559,22 @@ describe Manticore::Client do
     it "raises InvalidUriException for illegal character in URI" do
       expect { client.get(local_server + "?foo=bar{{{", query: {"baz" => "bin"})}
         .to raise_exception(Manticore::InvalidUriException)
+    end
+
+    describe "body" do
+      let(:params) { { body: body } }
+      context "when there is no body" do
+        let(:body) { nil }
+        it "does not send http get with entity" do
+          expect(client.get("http://google.com", params).request).to_not respond_to(:entity)
+        end
+      end
+      context "when there is a body" do
+        let(:body) { "hello" }
+        it "sends http get with entity" do
+          expect(client.get("http://google.com", params).request).to respond_to(:entity)
+        end
+      end
     end
   end
 
@@ -630,6 +646,22 @@ describe Manticore::Client do
     it "sends a body" do
       response = client.delete(local_server, body: "This is a delete body")
       expect(JSON.load(response.body)["body"]).to eq "This is a delete body"
+    end
+
+    describe "body" do
+      let(:params) { { body: body } }
+      context "when there is no body" do
+        let(:body) { nil }
+        it "does not send http get with entity" do
+          expect(client.delete("http://google.com", params).request).to_not respond_to(:entity)
+        end
+      end
+      context "when there is a body" do
+        let(:body) { "hello" }
+        it "sends http get with entity" do
+          expect(client.delete("http://google.com", params).request).to respond_to(:entity)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently a non-body get/delete will sent a "Content-Length: 0" header given the httpclient is passed a request object with Entity.

While RFC 7230 does allow for non-body requests to have "Content-Length: 0" it is marked as a SHOULD NOT and can cause problems in stricter environments.

This commit changes that, where a no body request will use non-entity objects.

fixes https://github.com/logstash-plugins/logstash-input-http_poller/issues/150